### PR TITLE
Annotate name fix

### DIFF
--- a/R/annotate.R
+++ b/R/annotate.R
@@ -36,6 +36,12 @@
 #'
 #' impute_feature(gr, features_gr, "name", ignore.strand = TRUE)
 impute_feature <- function(gr, feature_gr, name_field, minoverlap = 1L, ignore.strand = TRUE) {
+  if ("feature" %in% names(GenomicRanges::mcols(gr))) {
+    msg <- "Target GRanges already has a feature field. Previous annotation will be dropped"
+    warning(msg)
+    gr$feature <- NULL
+  }
+
   # Again this problem with levels not exactly matching, which happens a lot
   hits <- suppressWarnings(
     findOverlaps(

--- a/tests/testthat/test-annotate.R
+++ b/tests/testthat/test-annotate.R
@@ -16,6 +16,49 @@ test_that("impute_feature() imputes best jaccard overlapping feature", {
   expect_equal(result$feature[1], "Feat_A")
 })
 
+test_that("impute_feature() does not fail with already named GRanges", {
+  features_gr <- GenomicRanges::GRanges(
+    seqnames = c("chr1", "chr1"),
+    IRanges::IRanges(c(10,22), c(20,30)),
+    strand = c("-", "-"),
+    name = c("Feat_A", "Feat_B")
+  )
+
+  gr <- GenomicRanges::GRanges(
+    seqnames = c("chr1"),
+    IRanges::IRanges(15, 25),
+    strand = "+",
+    name = "my_range"
+  )
+
+  result <- impute_feature(gr, features_gr, "name", ignore.strand = TRUE)
+  expect_equal(result$feature[1], "Feat_A")
+})
+
+test_that("impute_feature() throws a warning and overwrites with already annotated GRanges", {
+  features_gr <- GenomicRanges::GRanges(
+    seqnames = c("chr1", "chr1"),
+    IRanges::IRanges(c(10,22), c(20,30)),
+    strand = c("-", "-"),
+    name = c("Feat_A", "Feat_B")
+  )
+
+  gr <- GenomicRanges::GRanges(
+    seqnames = c("chr1"),
+    IRanges::IRanges(15, 25),
+    strand = "+",
+    feature = "my_range"
+  )
+
+  expect_warning(
+    result <- impute_feature(gr, features_gr, "name", ignore.strand = TRUE),
+    "Target GRanges already has a feature field. Previous annotation will be dropped"
+  )
+
+  expect_equal(result$feature[1], "Feat_A")
+})
+
+
 test_that("impute_feature() returns a GRanges object", {
   features_gr <- GenomicRanges::GRanges(
     seqnames = c("chr1", "chr1"),


### PR DESCRIPTION
Both annotation functions would not handle properly when target `GRanges` already have the same name for the resulting annotated feature. One way to fix this in a simple way is to overwrite and throw a warning, as generally when annotating one would not care for previous annotations, and those names `feature` and `nearby_features` are not so common.

Fixes #11 