### PR TITLE
Simplified vignette document

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bedscout
 Title: Simple arithmetic and visualizations on BED files
-Version: 0.0.0.9004
+Version: 0.0.0.9005
 Authors@R: 
     person("Carmen", "Navarro", , "carmen.navarro@scilifelab.se", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5438-9654"))
@@ -25,7 +25,6 @@ Imports: GenomicRanges,
 Suggests: 
     knitr,
     rmarkdown,
-    prettydoc,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# bedscout 0.0.0.9005 - 22/07/2024
+
+* vignettes now use default format HTML vignette.
+* prettydoc suggestion is now removed.
+
 # bedscout 0.0.0.9004 - 22/07/2024
 
 * peaks_universe function makes use of loci_consensus to obtain a universe of

--- a/vignettes/bedscout.Rmd
+++ b/vignettes/bedscout.Rmd
@@ -1,9 +1,7 @@
 ---
 title: "bedscout"
 output:
-  prettydoc::html_pretty:
-    theme: cayman
-    highlight: github
+  rmarkdown::html_vignette:
     toc: true
 vignette: >
   %\VignetteIndexEntry{bedscout}
@@ -15,6 +13,8 @@ vignette: >
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
+  fig.width = 5,
+  fig.height = 5,
   comment = "#>"
 )
 ```


### PR DESCRIPTION
Removed the prettydoc dependency at the cost of an uglier vignette, but also more lightweight and CRAN compliant if I wanted to submit.