### PR TITLE
Fixes on impute_feature function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bedscout
 Title: Simple arithmetic and visualizations on BED files
-Version: 0.0.0.9008
+Version: 0.0.0.9009
 Authors@R: 
     person("Carmen", "Navarro", , "carmen.navarro@scilifelab.se", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5438-9654"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# bedscout 0.0.0.9009 - 16/04/2026
+
+* impute_feature now outputs impute_score column instead of score to avoid conflict
+with usual column names. It also checks for impute_score column in the query
+genomic ranges and throws a warning on overwrite.
+
+* Fix: impute_feature actually outputs column named "annotation" instead of 
+"feature".
+
 # bedscout 0.0.0.9008 - 02/04/2026
 
 * gr_universe now returns a source column that is a comma separated list of 
@@ -5,7 +14,6 @@ the provenance label. If no label is assigned, generic labels will be added.
 * impute_feature, annotate_nearest_features, annotate_overlapping_features,
 annotate_nearby_features, all return a "annotation" column instead of the old
 "nearby_features".
-
 
 # bedscout 0.0.0.9007 - 01/04/2026
 

--- a/R/annotate.R
+++ b/R/annotate.R
@@ -40,10 +40,10 @@
 #'
 #' impute_feature(gr, features_gr, "name", ignore.strand = TRUE)
 impute_feature <- function(gr, feature_gr, name_field, minoverlap = 1L, ignore.strand = TRUE, with_ties = TRUE) {
-  if ("feature" %in% names(GenomicRanges::mcols(gr))) {
-    msg <- "Target GRanges already has a feature field. Previous annotation will be dropped"
+  if ("annotation" %in% names(GenomicRanges::mcols(gr))) {
+    msg <- "Target GRanges already has an annotation field. Previous annotation will be dropped"
     warning(msg)
-    gr$feature <- NULL
+    gr$annotation <- NULL
   }
 
   if ("impute_score" %in% names(GenomicRanges::mcols(gr))) {
@@ -79,11 +79,11 @@ impute_feature <- function(gr, feature_gr, name_field, minoverlap = 1L, ignore.s
   best_annotated_df <- cbind(
     cbind(
       data.frame(gr[annotated_hits$queryHits, ]),
-      feature = data.frame(feature_gr)[annotated_hits$subjectHits, name_field]
+      annotation = data.frame(feature_gr)[annotated_hits$subjectHits, name_field]
     ), impute_score = annotated_hits$impute_score
   ) %>%
     dplyr::summarise(
-      feature = paste(sort(unique(.data$feature)), collapse = ","),
+      annotation = paste(sort(unique(.data$annotation)), collapse = ","),
       .by = all_of(c("seqnames", "start", "end", "strand", "impute_score", "width"))
     )
 

--- a/R/annotate.R
+++ b/R/annotate.R
@@ -46,6 +46,12 @@ impute_feature <- function(gr, feature_gr, name_field, minoverlap = 1L, ignore.s
     gr$feature <- NULL
   }
 
+  if ("impute_score" %in% names(GenomicRanges::mcols(gr))) {
+    msg <- "Target GRanges already has a impute_score field. Previous annotation will be dropped"
+    warning(msg)
+    gr$impute_score <- NULL
+  }
+
   # Again this problem with levels not exactly matching, which happens a lot
   hits <- suppressWarnings(
     findOverlaps(
@@ -66,19 +72,19 @@ impute_feature <- function(gr, feature_gr, name_field, minoverlap = 1L, ignore.s
   annotated_hits <- cbind(
       data.frame(hits), scores
     ) %>%
-    dplyr::rename(score = 3) %>%
+    dplyr::rename(impute_score = 3) %>%
     dplyr::group_by(queryHits) %>%
-    dplyr::slice_max(.data$score, na_rm = TRUE, with_ties = with_ties)
+    dplyr::slice_max(.data$impute_score, na_rm = TRUE, with_ties = with_ties)
 
   best_annotated_df <- cbind(
     cbind(
       data.frame(gr[annotated_hits$queryHits, ]),
       feature = data.frame(feature_gr)[annotated_hits$subjectHits, name_field]
-    ), score = annotated_hits$score
+    ), impute_score = annotated_hits$impute_score
   ) %>%
     dplyr::summarise(
       feature = paste(sort(unique(.data$feature)), collapse = ","),
-      .by = all_of(c("seqnames", "start", "end", "strand", "score", "width"))
+      .by = all_of(c("seqnames", "start", "end", "strand", "impute_score", "width"))
     )
 
   id_cols <- setdiff(colnames(data.frame(gr)), colnames(S4Vectors::mcols(gr)))

--- a/tests/testthat/test-annotate.R
+++ b/tests/testthat/test-annotate.R
@@ -13,7 +13,7 @@ test_that("impute_feature() imputes best jaccard overlapping feature", {
   )
 
   result <- impute_feature(gr, features_gr, "name", ignore.strand = TRUE)
-  expect_equal(result$feature[1], "Feat_A")
+  expect_equal(result$annotation[1], "Feat_A")
 })
 
 test_that("impute_feature() returns all jaccard overlapping features if with_ties == TRUE", {
@@ -31,7 +31,7 @@ test_that("impute_feature() returns all jaccard overlapping features if with_tie
   )
 
   result <- impute_feature(gr, features_gr, "name", ignore.strand = TRUE, with_ties = TRUE)
-  expect_equal(result$feature[1], "Feat_A,Feat_B")
+  expect_equal(result$annotation[1], "Feat_A,Feat_B")
 })
 
 test_that("impute_feature() throws a warning if query GRanges already has a impute_score column", {
@@ -54,7 +54,7 @@ test_that("impute_feature() throws a warning if query GRanges already has a impu
     result <- impute_feature(gr, features_gr, "name", ignore.strand = TRUE, with_ties = TRUE),
     "Target GRanges already has a impute_score field. Previous annotation will be dropped"
   )
-  expect_equal(result$feature[1], "Feat_A,Feat_B")
+  expect_equal(result$annotation[1], "Feat_A,Feat_B")
 })
 
 test_that("impute_feature() returns all jaccard overlapping features (deduplicated) if with_ties == TRUE", {
@@ -72,7 +72,7 @@ test_that("impute_feature() returns all jaccard overlapping features (deduplicat
   )
 
   result <- impute_feature(gr, features_gr, "name", ignore.strand = TRUE, with_ties = TRUE)
-  expect_equal(result$feature[1], "Feat_A,Feat_B")
+  expect_equal(result$annotation[1], "Feat_A,Feat_B")
 })
 
 
@@ -91,7 +91,7 @@ test_that("impute_feature() returns first jaccard overlapping features if with_t
   )
 
   result <- impute_feature(gr, features_gr, "name", ignore.strand = TRUE, with_ties = FALSE)
-  expect_equal(result$feature[1], "Feat_A")
+  expect_equal(result$annotation[1], "Feat_A")
 })
 
 test_that("impute_feature() does not fail with already named GRanges", {
@@ -110,7 +110,7 @@ test_that("impute_feature() does not fail with already named GRanges", {
   )
 
   result <- impute_feature(gr, features_gr, "name", ignore.strand = TRUE)
-  expect_equal(result$feature[1], "Feat_A")
+  expect_equal(result$annotation[1], "Feat_A")
 })
 
 test_that("impute_feature() throws a warning and overwrites with already annotated GRanges", {
@@ -125,15 +125,15 @@ test_that("impute_feature() throws a warning and overwrites with already annotat
     seqnames = c("chr1"),
     IRanges::IRanges(15, 25),
     strand = "+",
-    feature = "my_range"
+    annotation = "my_range"
   )
 
   expect_warning(
     result <- impute_feature(gr, features_gr, "name", ignore.strand = TRUE),
-    "Target GRanges already has a feature field. Previous annotation will be dropped"
+    "Target GRanges already has an annotation field. Previous annotation will be dropped"
   )
 
-  expect_equal(result$feature[1], "Feat_A")
+  expect_equal(result$annotation[1], "Feat_A")
 })
 
 
@@ -170,7 +170,7 @@ test_that("impute_feature() returns a NA if no overlaps are found", {
   )
 
   result <- impute_feature(gr, features_gr, "name", ignore.strand = TRUE)
-  expect_true(is.na(result$feature[1]))
+  expect_true(is.na(result$annotation[1]))
 })
 
 test_that("impute_feature() throws no warnings if no overlapping seqnames", {
@@ -224,7 +224,7 @@ test_that("impute_feature() returns correct values with ignore.strand = FALSE", 
   )
 
   result <- impute_feature(gr, features_gr, "name", ignore.strand = FALSE)
-  expect_equal(result$feature[1], "Feat_B")
+  expect_equal(result$annotation[1], "Feat_B")
 })
 
 test_that("annotate_nearby_features() gives correct features", {

--- a/tests/testthat/test-annotate.R
+++ b/tests/testthat/test-annotate.R
@@ -34,6 +34,29 @@ test_that("impute_feature() returns all jaccard overlapping features if with_tie
   expect_equal(result$feature[1], "Feat_A,Feat_B")
 })
 
+test_that("impute_feature() throws a warning if query GRanges already has a impute_score column", {
+  features_gr <- GenomicRanges::GRanges(
+    seqnames = c("chr1", "chr1"),
+    IRanges::IRanges(c(10,20), c(21,31)),
+    strand = c("-", "-"),
+    name = c("Feat_A", "Feat_B")
+  )
+
+  gr <- GenomicRanges::GRanges(
+    seqnames = c("chr1"),
+    IRanges::IRanges(9, 35),
+    strand = "+",
+    name = c("gene_A"),
+    impute_score = c(0)
+  )
+
+  expect_warning(
+    result <- impute_feature(gr, features_gr, "name", ignore.strand = TRUE, with_ties = TRUE),
+    "Target GRanges already has a impute_score field. Previous annotation will be dropped"
+  )
+  expect_equal(result$feature[1], "Feat_A,Feat_B")
+})
+
 test_that("impute_feature() returns all jaccard overlapping features (deduplicated) if with_ties == TRUE", {
   features_gr <- GenomicRanges::GRanges(
     seqnames = c("chr1", "chr1", "chr1"),


### PR DESCRIPTION
The last PR #24 claims that all annotation functions return an `annotation` column but `impute_feature` still was returning `feature`.

So the changes:
* `impute_feature` returns a `annotation` column, in line with the rest of the annotation functions.
* `impute_feature` returns a `impute_score` column instead of `score`. This reduces probability of collision with many `GRanges` objects that actually have a `score` column, since that is the name of one of the 6-BED fields. Additionally, a check is added to the function so if the query `GRanges` does already have a `impute_score` column, it effectively overwrites it and throws a warning about it.
